### PR TITLE
Use actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,3 +13,8 @@ jobs:
         run: make build
       - name: Run make check
         run: make check
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build_nwa
+          path: output/app.nwa


### PR DESCRIPTION
Update workflows (integrate artifact upload)
- Add a GitHub Actions step using actions/upload-artifact@v4 to publish .nwa for easy download